### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,32 +10,32 @@
 # Instances (KEYWORD2)
 #######################################
 Quaternion	KEYWORD2
-Vector3		KEYWORD2
+Vector3	KEYWORD2
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-set				KEYWORD2
-scl				KEYWORD2
-nor				KEYWORD2
-dot				KEYWORD2
-len				KEYWORD2
-transform		KEYWORD2
-lerp			KEYWORD2
-slerp			KEYWORD2
-idt				KEYWORD2
-conjugate		KEYWORD2
-mul				KEYWORD2
-mulLeft			KEYWORD2
-setFromAxis		KEYWORD2
+set	KEYWORD2
+scl	KEYWORD2
+nor	KEYWORD2
+dot	KEYWORD2
+len	KEYWORD2
+transform	KEYWORD2
+lerp	KEYWORD2
+slerp	KEYWORD2
+idt	KEYWORD2
+conjugate	KEYWORD2
+mul	KEYWORD2
+mulLeft	KEYWORD2
+setFromAxis	KEYWORD2
 setFromCross	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 Q_FP_ERR	LITERAL1
-Q_PI		LITERAL1
-Q_PI2		LITERAL1
+Q_PI	LITERAL1
+Q_PI2	LITERAL1
 Q_RADDEG	LITERAL1
 Q_DEGRAD	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords